### PR TITLE
Refactor updaters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/nandaryanizar/gopartial
+
+go 1.14
+
+require github.com/guregu/null v4.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/guregu/null v4.0.0+incompatible h1:4zw0ckM7ECd6FNNddc3Fu4aty9nTlpkkzH7dPn4/4Gw=
+github.com/guregu/null v4.0.0+incompatible/go.mod h1:ePGpQaN9cw0tj45IR5E5ehMvsFlLlQZAkkOXZurJ3NM=

--- a/gopartial_test.go
+++ b/gopartial_test.go
@@ -135,48 +135,48 @@ func TestPartialUpdate(t *testing.T) {
 		},
 
 		// null.String
-		//test{
-		//	name: "Update field2 (null.String) with string",
-		//	args: args{
-		//		dest: &destination{},
-		//		partial: map[string]interface{}{
-		//			"field2": str,
-		//		},
-		//		tagName:        "json",
-		//		updaters:       Updaters,
-		//		skipConditions: SkipConditions,
-		//	},
-		//	want:    []string{"Field2"},
-		//	wantErr: false,
-		//},
-		//test{
-		//	name: "Update field2 (null.String) with null",
-		//	args: args{
-		//		dest: &destination{},
-		//		partial: map[string]interface{}{
-		//			"field2": nil,
-		//		},
-		//		tagName:        "json",
-		//		updaters:       Updaters,
-		//		skipConditions: SkipConditions,
-		//	},
-		//	want:    []string{"Field2"},
-		//	wantErr: false,
-		//},
-		//test{
-		//	name: "Update field2 (null.String) with int",
-		//	args: args{
-		//		dest: &destination{},
-		//		partial: map[string]interface{}{
-		//			"field2": i,
-		//		},
-		//		tagName:        "json",
-		//		updaters:       Updaters,
-		//		skipConditions: SkipConditions,
-		//	},
-		//	want:    nil,
-		//	wantErr: true,
-		//},
+		test{
+			name: "Update field2 (null.String) with string",
+			args: args{
+				dest: &destination{},
+				partial: map[string]interface{}{
+					"field2": str,
+				},
+				tagName:        "json",
+				updaters:       AllUpdaters,
+				skipConditions: SkipConditions,
+			},
+			want:    []string{"Field2"},
+			wantErr: false,
+		},
+		test{
+			name: "Update field2 (null.String) with null",
+			args: args{
+				dest: &destination{},
+				partial: map[string]interface{}{
+					"field2": nil,
+				},
+				tagName:        "json",
+				updaters:       AllUpdaters,
+				skipConditions: SkipConditions,
+			},
+			want:    []string{"Field2"},
+			wantErr: false,
+		},
+		test{
+			name: "Update field2 (null.String) with int",
+			args: args{
+				dest: &destination{},
+				partial: map[string]interface{}{
+					"field2": i,
+				},
+				tagName:        "json",
+				updaters:       AllUpdaters,
+				skipConditions: SkipConditions,
+			},
+			want:    nil,
+			wantErr: true,
+		},
 
 		// float64
 		test{
@@ -421,132 +421,132 @@ func TestPartialUpdate(t *testing.T) {
 		},
 
 		// null.Float
-		//test{
-		//	name: "Update field4 (null.Float) with float32",
-		//	args: args{
-		//		dest: &destination{},
-		//		partial: map[string]interface{}{
-		//			"field4": f32,
-		//		},
-		//		tagName:        "json",
-		//		updaters:       Updaters,
-		//		skipConditions: SkipConditions,
-		//	},
-		//	want:    []string{"Field4"},
-		//	wantErr: false,
-		//},
-		//test{
-		//	name: "Update field4 (null.Float) with float64",
-		//	args: args{
-		//		dest: &destination{},
-		//		partial: map[string]interface{}{
-		//			"field4": f64,
-		//		},
-		//		tagName:        "json",
-		//		updaters:       Updaters,
-		//		skipConditions: SkipConditions,
-		//	},
-		//	want:    []string{"Field4"},
-		//	wantErr: false,
-		//},
-		//test{
-		//	name: "Update field4 (null.Float) with int",
-		//	args: args{
-		//		dest: &destination{},
-		//		partial: map[string]interface{}{
-		//			"field4": i,
-		//		},
-		//		tagName:        "json",
-		//		updaters:       Updaters,
-		//		skipConditions: SkipConditions,
-		//	},
-		//	want:    []string{"Field4"},
-		//	wantErr: false,
-		//},
-		//test{
-		//	name: "Update field4 (null.Float) with int8",
-		//	args: args{
-		//		dest: &destination{},
-		//		partial: map[string]interface{}{
-		//			"field4": i8,
-		//		},
-		//		tagName:        "json",
-		//		updaters:       Updaters,
-		//		skipConditions: SkipConditions,
-		//	},
-		//	want:    []string{"Field4"},
-		//	wantErr: false,
-		//},
-		//test{
-		//	name: "Update field4 (null.Float) with int16",
-		//	args: args{
-		//		dest: &destination{},
-		//		partial: map[string]interface{}{
-		//			"field4": i16,
-		//		},
-		//		tagName:        "json",
-		//		updaters:       Updaters,
-		//		skipConditions: SkipConditions,
-		//	},
-		//	want:    []string{"Field4"},
-		//	wantErr: false,
-		//},
-		//test{
-		//	name: "Update field4 (null.Float) with int32",
-		//	args: args{
-		//		dest: &destination{},
-		//		partial: map[string]interface{}{
-		//			"field4": i32,
-		//		},
-		//		tagName:        "json",
-		//		updaters:       Updaters,
-		//		skipConditions: SkipConditions,
-		//	},
-		//	want:    []string{"Field4"},
-		//	wantErr: false,
-		//},
-		//test{
-		//	name: "Update field4 (null.Float) with int64",
-		//	args: args{
-		//		dest: &destination{},
-		//		partial: map[string]interface{}{
-		//			"field4": i64,
-		//		},
-		//		tagName:        "json",
-		//		updaters:       Updaters,
-		//		skipConditions: SkipConditions,
-		//	},
-		//	want:    []string{"Field4"},
-		//	wantErr: false,
-		//},
-		//test{
-		//	name: "Update field4 (null.Float) with null",
-		//	args: args{
-		//		dest: &destination{},
-		//		partial: map[string]interface{}{
-		//			"field4": nil,
-		//		},
-		//		tagName:        "json",
-		//		updaters:       Updaters,
-		//		skipConditions: SkipConditions,
-		//	},
-		//	want:    []string{"Field4"},
-		//	wantErr: false,
-		//},
-		//test{
-		//	name: "Update field4 (null.Int) with string",
-		//	args: args{
-		//		dest: &destination{},
-		//		partial: map[string]interface{}{
-		//			"field4": str,
-		//		},
-		//		tagName:        "json",
-		//		updaters:       Updaters,
-		//		skipConditions: SkipConditions,
-		//	},
-		//	want:    nil,
-		//	wantErr: true,
-		//},
+		test{
+			name: "Update field4 (null.Float) with float32",
+			args: args{
+				dest: &destination{},
+				partial: map[string]interface{}{
+					"field4": f32,
+				},
+				tagName:        "json",
+				updaters:       AllUpdaters,
+				skipConditions: SkipConditions,
+			},
+			want:    []string{"Field4"},
+			wantErr: false,
+		},
+		test{
+			name: "Update field4 (null.Float) with float64",
+			args: args{
+				dest: &destination{},
+				partial: map[string]interface{}{
+					"field4": f64,
+				},
+				tagName:        "json",
+				updaters:       AllUpdaters,
+				skipConditions: SkipConditions,
+			},
+			want:    []string{"Field4"},
+			wantErr: false,
+		},
+		test{
+			name: "Update field4 (null.Float) with int",
+			args: args{
+				dest: &destination{},
+				partial: map[string]interface{}{
+					"field4": i,
+				},
+				tagName:        "json",
+				updaters:       AllUpdaters,
+				skipConditions: SkipConditions,
+			},
+			want:    []string{"Field4"},
+			wantErr: false,
+		},
+		test{
+			name: "Update field4 (null.Float) with int8",
+			args: args{
+				dest: &destination{},
+				partial: map[string]interface{}{
+					"field4": i8,
+				},
+				tagName:        "json",
+				updaters:       AllUpdaters,
+				skipConditions: SkipConditions,
+			},
+			want:    []string{"Field4"},
+			wantErr: false,
+		},
+		test{
+			name: "Update field4 (null.Float) with int16",
+			args: args{
+				dest: &destination{},
+				partial: map[string]interface{}{
+					"field4": i16,
+				},
+				tagName:        "json",
+				updaters:       AllUpdaters,
+				skipConditions: SkipConditions,
+			},
+			want:    []string{"Field4"},
+			wantErr: false,
+		},
+		test{
+			name: "Update field4 (null.Float) with int32",
+			args: args{
+				dest: &destination{},
+				partial: map[string]interface{}{
+					"field4": i32,
+				},
+				tagName:        "json",
+				updaters:       AllUpdaters,
+				skipConditions: SkipConditions,
+			},
+			want:    []string{"Field4"},
+			wantErr: false,
+		},
+		test{
+			name: "Update field4 (null.Float) with int64",
+			args: args{
+				dest: &destination{},
+				partial: map[string]interface{}{
+					"field4": i64,
+				},
+				tagName:        "json",
+				updaters:       AllUpdaters,
+				skipConditions: SkipConditions,
+			},
+			want:    []string{"Field4"},
+			wantErr: false,
+		},
+		test{
+			name: "Update field4 (null.Float) with null",
+			args: args{
+				dest: &destination{},
+				partial: map[string]interface{}{
+					"field4": nil,
+				},
+				tagName:        "json",
+				updaters:       AllUpdaters,
+				skipConditions: SkipConditions,
+			},
+			want:    []string{"Field4"},
+			wantErr: false,
+		},
+		test{
+			name: "Update field4 (null.Int) with string",
+			args: args{
+				dest: &destination{},
+				partial: map[string]interface{}{
+					"field4": str,
+				},
+				tagName:        "json",
+				updaters:       AllUpdaters,
+				skipConditions: SkipConditions,
+			},
+			want:    nil,
+			wantErr: true,
+		},
 
 		// int
 		test{
@@ -791,132 +791,132 @@ func TestPartialUpdate(t *testing.T) {
 		},
 
 		// null.Int
-		//test{
-		//	name: "Update field6 (null.Int) with int",
-		//	args: args{
-		//		dest: &destination{},
-		//		partial: map[string]interface{}{
-		//			"field6": i,
-		//		},
-		//		tagName:        "json",
-		//		updaters:       Updaters,
-		//		skipConditions: SkipConditions,
-		//	},
-		//	want:    []string{"Field6"},
-		//	wantErr: false,
-		//},
-		//test{
-		//	name: "Update field6 (null.Int) with int8",
-		//	args: args{
-		//		dest: &destination{},
-		//		partial: map[string]interface{}{
-		//			"field6": i8,
-		//		},
-		//		tagName:        "json",
-		//		updaters:       Updaters,
-		//		skipConditions: SkipConditions,
-		//	},
-		//	want:    []string{"Field6"},
-		//	wantErr: false,
-		//},
-		//test{
-		//	name: "Update field6 (null.Int) with int16",
-		//	args: args{
-		//		dest: &destination{},
-		//		partial: map[string]interface{}{
-		//			"field6": i16,
-		//		},
-		//		tagName:        "json",
-		//		updaters:       Updaters,
-		//		skipConditions: SkipConditions,
-		//	},
-		//	want:    []string{"Field6"},
-		//	wantErr: false,
-		//},
-		//test{
-		//	name: "Update field6 (null.Int) with int32",
-		//	args: args{
-		//		dest: &destination{},
-		//		partial: map[string]interface{}{
-		//			"field6": i32,
-		//		},
-		//		tagName:        "json",
-		//		updaters:       Updaters,
-		//		skipConditions: SkipConditions,
-		//	},
-		//	want:    []string{"Field6"},
-		//	wantErr: false,
-		//},
-		//test{
-		//	name: "Update field6 (null.Int) with int64",
-		//	args: args{
-		//		dest: &destination{},
-		//		partial: map[string]interface{}{
-		//			"field6": i64,
-		//		},
-		//		tagName:        "json",
-		//		updaters:       Updaters,
-		//		skipConditions: SkipConditions,
-		//	},
-		//	want:    []string{"Field6"},
-		//	wantErr: false,
-		//},
-		//test{
-		//	name: "Update field6 (null.Int) with float32",
-		//	args: args{
-		//		dest: &destination{},
-		//		partial: map[string]interface{}{
-		//			"field6": f32,
-		//		},
-		//		tagName:        "json",
-		//		updaters:       Updaters,
-		//		skipConditions: SkipConditions,
-		//	},
-		//	want:    []string{"Field6"},
-		//	wantErr: false,
-		//},
-		//test{
-		//	name: "Update field6 (null.Int) with float64",
-		//	args: args{
-		//		dest: &destination{},
-		//		partial: map[string]interface{}{
-		//			"field6": f64,
-		//		},
-		//		tagName:        "json",
-		//		updaters:       Updaters,
-		//		skipConditions: SkipConditions,
-		//	},
-		//	want:    []string{"Field6"},
-		//	wantErr: false,
-		//},
-		//test{
-		//	name: "Update field6 (null.Int) with null",
-		//	args: args{
-		//		dest: &destination{},
-		//		partial: map[string]interface{}{
-		//			"field6": nil,
-		//		},
-		//		tagName:        "json",
-		//		updaters:       Updaters,
-		//		skipConditions: SkipConditions,
-		//	},
-		//	want:    []string{"Field6"},
-		//	wantErr: false,
-		//},
-		//test{
-		//	name: "Update field6 (null.Int) with string",
-		//	args: args{
-		//		dest: &destination{},
-		//		partial: map[string]interface{}{
-		//			"field6": str,
-		//		},
-		//		tagName:        "json",
-		//		updaters:       Updaters,
-		//		skipConditions: SkipConditions,
-		//	},
-		//	want:    nil,
-		//	wantErr: true,
-		//},
+		test{
+			name: "Update field6 (null.Int) with int",
+			args: args{
+				dest: &destination{},
+				partial: map[string]interface{}{
+					"field6": i,
+				},
+				tagName:        "json",
+				updaters:       AllUpdaters,
+				skipConditions: SkipConditions,
+			},
+			want:    []string{"Field6"},
+			wantErr: false,
+		},
+		test{
+			name: "Update field6 (null.Int) with int8",
+			args: args{
+				dest: &destination{},
+				partial: map[string]interface{}{
+					"field6": i8,
+				},
+				tagName:        "json",
+				updaters:       AllUpdaters,
+				skipConditions: SkipConditions,
+			},
+			want:    []string{"Field6"},
+			wantErr: false,
+		},
+		test{
+			name: "Update field6 (null.Int) with int16",
+			args: args{
+				dest: &destination{},
+				partial: map[string]interface{}{
+					"field6": i16,
+				},
+				tagName:        "json",
+				updaters:       AllUpdaters,
+				skipConditions: SkipConditions,
+			},
+			want:    []string{"Field6"},
+			wantErr: false,
+		},
+		test{
+			name: "Update field6 (null.Int) with int32",
+			args: args{
+				dest: &destination{},
+				partial: map[string]interface{}{
+					"field6": i32,
+				},
+				tagName:        "json",
+				updaters:       AllUpdaters,
+				skipConditions: SkipConditions,
+			},
+			want:    []string{"Field6"},
+			wantErr: false,
+		},
+		test{
+			name: "Update field6 (null.Int) with int64",
+			args: args{
+				dest: &destination{},
+				partial: map[string]interface{}{
+					"field6": i64,
+				},
+				tagName:        "json",
+				updaters:       AllUpdaters,
+				skipConditions: SkipConditions,
+			},
+			want:    []string{"Field6"},
+			wantErr: false,
+		},
+		test{
+			name: "Update field6 (null.Int) with float32",
+			args: args{
+				dest: &destination{},
+				partial: map[string]interface{}{
+					"field6": f32,
+				},
+				tagName:        "json",
+				updaters:       AllUpdaters,
+				skipConditions: SkipConditions,
+			},
+			want:    []string{"Field6"},
+			wantErr: false,
+		},
+		test{
+			name: "Update field6 (null.Int) with float64",
+			args: args{
+				dest: &destination{},
+				partial: map[string]interface{}{
+					"field6": f64,
+				},
+				tagName:        "json",
+				updaters:       AllUpdaters,
+				skipConditions: SkipConditions,
+			},
+			want:    []string{"Field6"},
+			wantErr: false,
+		},
+		test{
+			name: "Update field6 (null.Int) with null",
+			args: args{
+				dest: &destination{},
+				partial: map[string]interface{}{
+					"field6": nil,
+				},
+				tagName:        "json",
+				updaters:       AllUpdaters,
+				skipConditions: SkipConditions,
+			},
+			want:    []string{"Field6"},
+			wantErr: false,
+		},
+		test{
+			name: "Update field6 (null.Int) with string",
+			args: args{
+				dest: &destination{},
+				partial: map[string]interface{}{
+					"field6": str,
+				},
+				tagName:        "json",
+				updaters:       AllUpdaters,
+				skipConditions: SkipConditions,
+			},
+			want:    nil,
+			wantErr: true,
+		},
 
 		// bool
 		test{
@@ -1123,48 +1123,48 @@ func TestPartialUpdate(t *testing.T) {
 		},
 
 		// null.Time
-		//test{
-		//	name: "Update field10 (null.Time) with datestring",
-		//	args: args{
-		//		dest: &destination{},
-		//		partial: map[string]interface{}{
-		//			"field10": dateStr,
-		//		},
-		//		tagName:        "json",
-		//		updaters:       Updaters,
-		//		skipConditions: SkipConditions,
-		//	},
-		//	want:    []string{"Field10"},
-		//	wantErr: false,
-		//},
-		//test{
-		//	name: "Update field10 (null.Time) with null",
-		//	args: args{
-		//		dest: &destination{},
-		//		partial: map[string]interface{}{
-		//			"field10": nil,
-		//		},
-		//		tagName:        "json",
-		//		updaters:       Updaters,
-		//		skipConditions: SkipConditions,
-		//	},
-		//	want:    []string{"Field10"},
-		//	wantErr: false,
-		//},
-		//test{
-		//	name: "Update field10 (null.Time) with int",
-		//	args: args{
-		//		dest: &destination{},
-		//		partial: map[string]interface{}{
-		//			"field10": 1,
-		//		},
-		//		tagName:        "json",
-		//		updaters:       Updaters,
-		//		skipConditions: SkipConditions,
-		//	},
-		//	want:    nil,
-		//	wantErr: true,
-		//},
+		test{
+			name: "Update field10 (null.Time) with datestring",
+			args: args{
+				dest: &destination{},
+				partial: map[string]interface{}{
+					"field10": dateStr,
+				},
+				tagName:        "json",
+				updaters:       AllUpdaters,
+				skipConditions: SkipConditions,
+			},
+			want:    []string{"Field10"},
+			wantErr: false,
+		},
+		test{
+			name: "Update field10 (null.Time) with null",
+			args: args{
+				dest: &destination{},
+				partial: map[string]interface{}{
+					"field10": nil,
+				},
+				tagName:        "json",
+				updaters:       AllUpdaters,
+				skipConditions: SkipConditions,
+			},
+			want:    []string{"Field10"},
+			wantErr: false,
+		},
+		test{
+			name: "Update field10 (null.Time) with int",
+			args: args{
+				dest: &destination{},
+				partial: map[string]interface{}{
+					"field10": 1,
+				},
+				tagName:        "json",
+				updaters:       AllUpdaters,
+				skipConditions: SkipConditions,
+			},
+			want:    nil,
+			wantErr: true,
+		},
 		test{
 			name: "Update field using field name",
 			args: args{

--- a/gopartial_test.go
+++ b/gopartial_test.go
@@ -47,6 +47,9 @@ func TestPartialUpdate(t *testing.T) {
 		Field10  null.Time   `json:"field10"`
 		Field11  sub         `json:"field11"`
 		Field11p *sub        `json:"field11p"`
+		Field12  uint        `json:"field12"`
+		Field12p *uint       `json:"field12p"`
+		Field13  int8        `json:"field13"`
 	}
 
 	var str = "foo"
@@ -132,48 +135,48 @@ func TestPartialUpdate(t *testing.T) {
 		},
 
 		// null.String
-		test{
-			name: "Update field2 (null.String) with string",
-			args: args{
-				dest: &destination{},
-				partial: map[string]interface{}{
-					"field2": str,
-				},
-				tagName:        "json",
-				updaters:       Updaters,
-				skipConditions: SkipConditions,
-			},
-			want:    []string{"Field2"},
-			wantErr: false,
-		},
-		test{
-			name: "Update field2 (null.String) with null",
-			args: args{
-				dest: &destination{},
-				partial: map[string]interface{}{
-					"field2": nil,
-				},
-				tagName:        "json",
-				updaters:       Updaters,
-				skipConditions: SkipConditions,
-			},
-			want:    []string{"Field2"},
-			wantErr: false,
-		},
-		test{
-			name: "Update field2 (null.String) with int",
-			args: args{
-				dest: &destination{},
-				partial: map[string]interface{}{
-					"field2": i,
-				},
-				tagName:        "json",
-				updaters:       Updaters,
-				skipConditions: SkipConditions,
-			},
-			want:    nil,
-			wantErr: true,
-		},
+		//test{
+		//	name: "Update field2 (null.String) with string",
+		//	args: args{
+		//		dest: &destination{},
+		//		partial: map[string]interface{}{
+		//			"field2": str,
+		//		},
+		//		tagName:        "json",
+		//		updaters:       Updaters,
+		//		skipConditions: SkipConditions,
+		//	},
+		//	want:    []string{"Field2"},
+		//	wantErr: false,
+		//},
+		//test{
+		//	name: "Update field2 (null.String) with null",
+		//	args: args{
+		//		dest: &destination{},
+		//		partial: map[string]interface{}{
+		//			"field2": nil,
+		//		},
+		//		tagName:        "json",
+		//		updaters:       Updaters,
+		//		skipConditions: SkipConditions,
+		//	},
+		//	want:    []string{"Field2"},
+		//	wantErr: false,
+		//},
+		//test{
+		//	name: "Update field2 (null.String) with int",
+		//	args: args{
+		//		dest: &destination{},
+		//		partial: map[string]interface{}{
+		//			"field2": i,
+		//		},
+		//		tagName:        "json",
+		//		updaters:       Updaters,
+		//		skipConditions: SkipConditions,
+		//	},
+		//	want:    nil,
+		//	wantErr: true,
+		//},
 
 		// float64
 		test{
@@ -418,132 +421,132 @@ func TestPartialUpdate(t *testing.T) {
 		},
 
 		// null.Float
-		test{
-			name: "Update field4 (null.Float) with float32",
-			args: args{
-				dest: &destination{},
-				partial: map[string]interface{}{
-					"field4": f32,
-				},
-				tagName:        "json",
-				updaters:       Updaters,
-				skipConditions: SkipConditions,
-			},
-			want:    []string{"Field4"},
-			wantErr: false,
-		},
-		test{
-			name: "Update field4 (null.Float) with float64",
-			args: args{
-				dest: &destination{},
-				partial: map[string]interface{}{
-					"field4": f64,
-				},
-				tagName:        "json",
-				updaters:       Updaters,
-				skipConditions: SkipConditions,
-			},
-			want:    []string{"Field4"},
-			wantErr: false,
-		},
-		test{
-			name: "Update field4 (null.Float) with int",
-			args: args{
-				dest: &destination{},
-				partial: map[string]interface{}{
-					"field4": i,
-				},
-				tagName:        "json",
-				updaters:       Updaters,
-				skipConditions: SkipConditions,
-			},
-			want:    []string{"Field4"},
-			wantErr: false,
-		},
-		test{
-			name: "Update field4 (null.Float) with int8",
-			args: args{
-				dest: &destination{},
-				partial: map[string]interface{}{
-					"field4": i8,
-				},
-				tagName:        "json",
-				updaters:       Updaters,
-				skipConditions: SkipConditions,
-			},
-			want:    []string{"Field4"},
-			wantErr: false,
-		},
-		test{
-			name: "Update field4 (null.Float) with int16",
-			args: args{
-				dest: &destination{},
-				partial: map[string]interface{}{
-					"field4": i16,
-				},
-				tagName:        "json",
-				updaters:       Updaters,
-				skipConditions: SkipConditions,
-			},
-			want:    []string{"Field4"},
-			wantErr: false,
-		},
-		test{
-			name: "Update field4 (null.Float) with int32",
-			args: args{
-				dest: &destination{},
-				partial: map[string]interface{}{
-					"field4": i32,
-				},
-				tagName:        "json",
-				updaters:       Updaters,
-				skipConditions: SkipConditions,
-			},
-			want:    []string{"Field4"},
-			wantErr: false,
-		},
-		test{
-			name: "Update field4 (null.Float) with int64",
-			args: args{
-				dest: &destination{},
-				partial: map[string]interface{}{
-					"field4": i64,
-				},
-				tagName:        "json",
-				updaters:       Updaters,
-				skipConditions: SkipConditions,
-			},
-			want:    []string{"Field4"},
-			wantErr: false,
-		},
-		test{
-			name: "Update field4 (null.Float) with null",
-			args: args{
-				dest: &destination{},
-				partial: map[string]interface{}{
-					"field4": nil,
-				},
-				tagName:        "json",
-				updaters:       Updaters,
-				skipConditions: SkipConditions,
-			},
-			want:    []string{"Field4"},
-			wantErr: false,
-		},
-		test{
-			name: "Update field4 (null.Int) with string",
-			args: args{
-				dest: &destination{},
-				partial: map[string]interface{}{
-					"field4": str,
-				},
-				tagName:        "json",
-				updaters:       Updaters,
-				skipConditions: SkipConditions,
-			},
-			want:    nil,
-			wantErr: true,
-		},
+		//test{
+		//	name: "Update field4 (null.Float) with float32",
+		//	args: args{
+		//		dest: &destination{},
+		//		partial: map[string]interface{}{
+		//			"field4": f32,
+		//		},
+		//		tagName:        "json",
+		//		updaters:       Updaters,
+		//		skipConditions: SkipConditions,
+		//	},
+		//	want:    []string{"Field4"},
+		//	wantErr: false,
+		//},
+		//test{
+		//	name: "Update field4 (null.Float) with float64",
+		//	args: args{
+		//		dest: &destination{},
+		//		partial: map[string]interface{}{
+		//			"field4": f64,
+		//		},
+		//		tagName:        "json",
+		//		updaters:       Updaters,
+		//		skipConditions: SkipConditions,
+		//	},
+		//	want:    []string{"Field4"},
+		//	wantErr: false,
+		//},
+		//test{
+		//	name: "Update field4 (null.Float) with int",
+		//	args: args{
+		//		dest: &destination{},
+		//		partial: map[string]interface{}{
+		//			"field4": i,
+		//		},
+		//		tagName:        "json",
+		//		updaters:       Updaters,
+		//		skipConditions: SkipConditions,
+		//	},
+		//	want:    []string{"Field4"},
+		//	wantErr: false,
+		//},
+		//test{
+		//	name: "Update field4 (null.Float) with int8",
+		//	args: args{
+		//		dest: &destination{},
+		//		partial: map[string]interface{}{
+		//			"field4": i8,
+		//		},
+		//		tagName:        "json",
+		//		updaters:       Updaters,
+		//		skipConditions: SkipConditions,
+		//	},
+		//	want:    []string{"Field4"},
+		//	wantErr: false,
+		//},
+		//test{
+		//	name: "Update field4 (null.Float) with int16",
+		//	args: args{
+		//		dest: &destination{},
+		//		partial: map[string]interface{}{
+		//			"field4": i16,
+		//		},
+		//		tagName:        "json",
+		//		updaters:       Updaters,
+		//		skipConditions: SkipConditions,
+		//	},
+		//	want:    []string{"Field4"},
+		//	wantErr: false,
+		//},
+		//test{
+		//	name: "Update field4 (null.Float) with int32",
+		//	args: args{
+		//		dest: &destination{},
+		//		partial: map[string]interface{}{
+		//			"field4": i32,
+		//		},
+		//		tagName:        "json",
+		//		updaters:       Updaters,
+		//		skipConditions: SkipConditions,
+		//	},
+		//	want:    []string{"Field4"},
+		//	wantErr: false,
+		//},
+		//test{
+		//	name: "Update field4 (null.Float) with int64",
+		//	args: args{
+		//		dest: &destination{},
+		//		partial: map[string]interface{}{
+		//			"field4": i64,
+		//		},
+		//		tagName:        "json",
+		//		updaters:       Updaters,
+		//		skipConditions: SkipConditions,
+		//	},
+		//	want:    []string{"Field4"},
+		//	wantErr: false,
+		//},
+		//test{
+		//	name: "Update field4 (null.Float) with null",
+		//	args: args{
+		//		dest: &destination{},
+		//		partial: map[string]interface{}{
+		//			"field4": nil,
+		//		},
+		//		tagName:        "json",
+		//		updaters:       Updaters,
+		//		skipConditions: SkipConditions,
+		//	},
+		//	want:    []string{"Field4"},
+		//	wantErr: false,
+		//},
+		//test{
+		//	name: "Update field4 (null.Int) with string",
+		//	args: args{
+		//		dest: &destination{},
+		//		partial: map[string]interface{}{
+		//			"field4": str,
+		//		},
+		//		tagName:        "json",
+		//		updaters:       Updaters,
+		//		skipConditions: SkipConditions,
+		//	},
+		//	want:    nil,
+		//	wantErr: true,
+		//},
 
 		// int
 		test{
@@ -788,132 +791,132 @@ func TestPartialUpdate(t *testing.T) {
 		},
 
 		// null.Int
-		test{
-			name: "Update field6 (null.Int) with int",
-			args: args{
-				dest: &destination{},
-				partial: map[string]interface{}{
-					"field6": i,
-				},
-				tagName:        "json",
-				updaters:       Updaters,
-				skipConditions: SkipConditions,
-			},
-			want:    []string{"Field6"},
-			wantErr: false,
-		},
-		test{
-			name: "Update field6 (null.Int) with int8",
-			args: args{
-				dest: &destination{},
-				partial: map[string]interface{}{
-					"field6": i8,
-				},
-				tagName:        "json",
-				updaters:       Updaters,
-				skipConditions: SkipConditions,
-			},
-			want:    []string{"Field6"},
-			wantErr: false,
-		},
-		test{
-			name: "Update field6 (null.Int) with int16",
-			args: args{
-				dest: &destination{},
-				partial: map[string]interface{}{
-					"field6": i16,
-				},
-				tagName:        "json",
-				updaters:       Updaters,
-				skipConditions: SkipConditions,
-			},
-			want:    []string{"Field6"},
-			wantErr: false,
-		},
-		test{
-			name: "Update field6 (null.Int) with int32",
-			args: args{
-				dest: &destination{},
-				partial: map[string]interface{}{
-					"field6": i32,
-				},
-				tagName:        "json",
-				updaters:       Updaters,
-				skipConditions: SkipConditions,
-			},
-			want:    []string{"Field6"},
-			wantErr: false,
-		},
-		test{
-			name: "Update field6 (null.Int) with int64",
-			args: args{
-				dest: &destination{},
-				partial: map[string]interface{}{
-					"field6": i64,
-				},
-				tagName:        "json",
-				updaters:       Updaters,
-				skipConditions: SkipConditions,
-			},
-			want:    []string{"Field6"},
-			wantErr: false,
-		},
-		test{
-			name: "Update field6 (null.Int) with float32",
-			args: args{
-				dest: &destination{},
-				partial: map[string]interface{}{
-					"field6": f32,
-				},
-				tagName:        "json",
-				updaters:       Updaters,
-				skipConditions: SkipConditions,
-			},
-			want:    []string{"Field6"},
-			wantErr: false,
-		},
-		test{
-			name: "Update field6 (null.Int) with float64",
-			args: args{
-				dest: &destination{},
-				partial: map[string]interface{}{
-					"field6": f64,
-				},
-				tagName:        "json",
-				updaters:       Updaters,
-				skipConditions: SkipConditions,
-			},
-			want:    []string{"Field6"},
-			wantErr: false,
-		},
-		test{
-			name: "Update field6 (null.Int) with null",
-			args: args{
-				dest: &destination{},
-				partial: map[string]interface{}{
-					"field6": nil,
-				},
-				tagName:        "json",
-				updaters:       Updaters,
-				skipConditions: SkipConditions,
-			},
-			want:    []string{"Field6"},
-			wantErr: false,
-		},
-		test{
-			name: "Update field6 (null.Int) with string",
-			args: args{
-				dest: &destination{},
-				partial: map[string]interface{}{
-					"field6": str,
-				},
-				tagName:        "json",
-				updaters:       Updaters,
-				skipConditions: SkipConditions,
-			},
-			want:    nil,
-			wantErr: true,
-		},
+		//test{
+		//	name: "Update field6 (null.Int) with int",
+		//	args: args{
+		//		dest: &destination{},
+		//		partial: map[string]interface{}{
+		//			"field6": i,
+		//		},
+		//		tagName:        "json",
+		//		updaters:       Updaters,
+		//		skipConditions: SkipConditions,
+		//	},
+		//	want:    []string{"Field6"},
+		//	wantErr: false,
+		//},
+		//test{
+		//	name: "Update field6 (null.Int) with int8",
+		//	args: args{
+		//		dest: &destination{},
+		//		partial: map[string]interface{}{
+		//			"field6": i8,
+		//		},
+		//		tagName:        "json",
+		//		updaters:       Updaters,
+		//		skipConditions: SkipConditions,
+		//	},
+		//	want:    []string{"Field6"},
+		//	wantErr: false,
+		//},
+		//test{
+		//	name: "Update field6 (null.Int) with int16",
+		//	args: args{
+		//		dest: &destination{},
+		//		partial: map[string]interface{}{
+		//			"field6": i16,
+		//		},
+		//		tagName:        "json",
+		//		updaters:       Updaters,
+		//		skipConditions: SkipConditions,
+		//	},
+		//	want:    []string{"Field6"},
+		//	wantErr: false,
+		//},
+		//test{
+		//	name: "Update field6 (null.Int) with int32",
+		//	args: args{
+		//		dest: &destination{},
+		//		partial: map[string]interface{}{
+		//			"field6": i32,
+		//		},
+		//		tagName:        "json",
+		//		updaters:       Updaters,
+		//		skipConditions: SkipConditions,
+		//	},
+		//	want:    []string{"Field6"},
+		//	wantErr: false,
+		//},
+		//test{
+		//	name: "Update field6 (null.Int) with int64",
+		//	args: args{
+		//		dest: &destination{},
+		//		partial: map[string]interface{}{
+		//			"field6": i64,
+		//		},
+		//		tagName:        "json",
+		//		updaters:       Updaters,
+		//		skipConditions: SkipConditions,
+		//	},
+		//	want:    []string{"Field6"},
+		//	wantErr: false,
+		//},
+		//test{
+		//	name: "Update field6 (null.Int) with float32",
+		//	args: args{
+		//		dest: &destination{},
+		//		partial: map[string]interface{}{
+		//			"field6": f32,
+		//		},
+		//		tagName:        "json",
+		//		updaters:       Updaters,
+		//		skipConditions: SkipConditions,
+		//	},
+		//	want:    []string{"Field6"},
+		//	wantErr: false,
+		//},
+		//test{
+		//	name: "Update field6 (null.Int) with float64",
+		//	args: args{
+		//		dest: &destination{},
+		//		partial: map[string]interface{}{
+		//			"field6": f64,
+		//		},
+		//		tagName:        "json",
+		//		updaters:       Updaters,
+		//		skipConditions: SkipConditions,
+		//	},
+		//	want:    []string{"Field6"},
+		//	wantErr: false,
+		//},
+		//test{
+		//	name: "Update field6 (null.Int) with null",
+		//	args: args{
+		//		dest: &destination{},
+		//		partial: map[string]interface{}{
+		//			"field6": nil,
+		//		},
+		//		tagName:        "json",
+		//		updaters:       Updaters,
+		//		skipConditions: SkipConditions,
+		//	},
+		//	want:    []string{"Field6"},
+		//	wantErr: false,
+		//},
+		//test{
+		//	name: "Update field6 (null.Int) with string",
+		//	args: args{
+		//		dest: &destination{},
+		//		partial: map[string]interface{}{
+		//			"field6": str,
+		//		},
+		//		tagName:        "json",
+		//		updaters:       Updaters,
+		//		skipConditions: SkipConditions,
+		//	},
+		//	want:    nil,
+		//	wantErr: true,
+		//},
 
 		// bool
 		test{
@@ -1046,6 +1049,34 @@ func TestPartialUpdate(t *testing.T) {
 			want:    nil,
 			wantErr: true,
 		},
+		test{
+			name: "Update field9 (time.Time) with int64 (unix time)",
+			args: args{
+				dest: &destination{},
+				partial: map[string]interface{}{
+					"field9": time.Now().Unix(),
+				},
+				tagName:        "json",
+				updaters:       Updaters,
+				skipConditions: SkipConditions,
+			},
+			want:    []string{"Field9"},
+			wantErr: false,
+		},
+		test{
+			name: "Update field9 (time.Time) with float64 (protobuf wkt struct)",
+			args: args{
+				dest: &destination{},
+				partial: map[string]interface{}{
+					"field9": float64(time.Now().Unix()),
+				},
+				tagName:        "json",
+				updaters:       Updaters,
+				skipConditions: SkipConditions,
+			},
+			want:    []string{"Field9"},
+			wantErr: false,
+		},
 
 		// *time.Time
 		test{
@@ -1092,48 +1123,48 @@ func TestPartialUpdate(t *testing.T) {
 		},
 
 		// null.Time
-		test{
-			name: "Update field10 (null.Time) with datestring",
-			args: args{
-				dest: &destination{},
-				partial: map[string]interface{}{
-					"field10": dateStr,
-				},
-				tagName:        "json",
-				updaters:       Updaters,
-				skipConditions: SkipConditions,
-			},
-			want:    []string{"Field10"},
-			wantErr: false,
-		},
-		test{
-			name: "Update field10 (null.Time) with null",
-			args: args{
-				dest: &destination{},
-				partial: map[string]interface{}{
-					"field10": nil,
-				},
-				tagName:        "json",
-				updaters:       Updaters,
-				skipConditions: SkipConditions,
-			},
-			want:    []string{"Field10"},
-			wantErr: false,
-		},
-		test{
-			name: "Update field10 (null.Time) with int",
-			args: args{
-				dest: &destination{},
-				partial: map[string]interface{}{
-					"field10": 1,
-				},
-				tagName:        "json",
-				updaters:       Updaters,
-				skipConditions: SkipConditions,
-			},
-			want:    nil,
-			wantErr: true,
-		},
+		//test{
+		//	name: "Update field10 (null.Time) with datestring",
+		//	args: args{
+		//		dest: &destination{},
+		//		partial: map[string]interface{}{
+		//			"field10": dateStr,
+		//		},
+		//		tagName:        "json",
+		//		updaters:       Updaters,
+		//		skipConditions: SkipConditions,
+		//	},
+		//	want:    []string{"Field10"},
+		//	wantErr: false,
+		//},
+		//test{
+		//	name: "Update field10 (null.Time) with null",
+		//	args: args{
+		//		dest: &destination{},
+		//		partial: map[string]interface{}{
+		//			"field10": nil,
+		//		},
+		//		tagName:        "json",
+		//		updaters:       Updaters,
+		//		skipConditions: SkipConditions,
+		//	},
+		//	want:    []string{"Field10"},
+		//	wantErr: false,
+		//},
+		//test{
+		//	name: "Update field10 (null.Time) with int",
+		//	args: args{
+		//		dest: &destination{},
+		//		partial: map[string]interface{}{
+		//			"field10": 1,
+		//		},
+		//		tagName:        "json",
+		//		updaters:       Updaters,
+		//		skipConditions: SkipConditions,
+		//	},
+		//	want:    nil,
+		//	wantErr: true,
+		//},
 		test{
 			name: "Update field using field name",
 			args: args{
@@ -1148,6 +1179,80 @@ func TestPartialUpdate(t *testing.T) {
 			},
 			want:    []string{},
 			wantErr: false,
+		},
+
+		// Test update to uint
+		test{
+			name: "Update uint using uint",
+			args: args{
+				dest: &destination{},
+				partial: map[string]interface{}{
+					"field12": uint(1),
+				},
+				tagName:        "json",
+				updaters:       Updaters,
+				skipConditions: SkipConditions,
+			},
+			want:    []string{"Field12"},
+			wantErr: false,
+		},
+		test{
+			name: "Update uint using int",
+			args: args{
+				dest: &destination{},
+				partial: map[string]interface{}{
+					"field12": 1,
+				},
+				tagName:        "json",
+				updaters:       Updaters,
+				skipConditions: SkipConditions,
+			},
+			want:    []string{"Field12"},
+			wantErr: false,
+		},
+		test{
+			name: "Update uint using float",
+			args: args{
+				dest: &destination{},
+				partial: map[string]interface{}{
+					"field12": 1.0,
+				},
+				tagName:        "json",
+				updaters:       Updaters,
+				skipConditions: SkipConditions,
+			},
+			want:    []string{"Field12"},
+			wantErr: false,
+		},
+
+		// Test overflow or underflow
+		test{
+			name: "Update uint underflow",
+			args: args{
+				dest: &destination{},
+				partial: map[string]interface{}{
+					"field12": -1,
+				},
+				tagName:        "json",
+				updaters:       Updaters,
+				skipConditions: SkipConditions,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		test{
+			name: "Update int overflow",
+			args: args{
+				dest: &destination{},
+				partial: map[string]interface{}{
+					"field13": 256,
+				},
+				tagName:        "json",
+				updaters:       Updaters,
+				skipConditions: SkipConditions,
+			},
+			want:    nil,
+			wantErr: true,
 		},
 	}
 

--- a/updaters.go
+++ b/updaters.go
@@ -805,7 +805,22 @@ func isOverflowFloat(field interface{}, value float64) bool {
 	return reflect.ValueOf(field).OverflowFloat(value)
 }
 
-// Updaters collection of all type updaters
+// AllUpdaters is a collection of all type updaters
+var AllUpdaters = []func(reflect.Value, reflect.Value) bool{
+	NullStringUpdater,
+	NullFloatUpdater,
+	NullIntUpdater,
+	NullBoolUpdater,
+	NullTimeUpdater,
+	MapStringInterfaceUpdater,
+	IntUpdater,
+	UintUpdater,
+	FloatUpdater,
+	TimeUpdater,
+	BoolUpdater,
+}
+
+// Updaters is a collection of standard type updaters
 var Updaters = []func(reflect.Value, reflect.Value) bool{
 	IntUpdater,
 	UintUpdater,

--- a/updaters.go
+++ b/updaters.go
@@ -116,7 +116,7 @@ func NullTimeUpdater(fieldValue reflect.Value, v reflect.Value) bool {
 	case null.Time:
 		// if its null value
 		if !v.IsValid() {
-			newValue := reflect.ValueOf(null.Time{Valid: false})
+			newValue := reflect.ValueOf(null.Time{})
 			fieldValue.Set(newValue)
 			return true
 		}

--- a/updaters.go
+++ b/updaters.go
@@ -172,119 +172,442 @@ func BoolUpdater(fieldValue reflect.Value, v reflect.Value) bool {
 
 // IntUpdater update int (any int type Int8, Int16, Int32, Int64 and whether its a pointer or a value)
 func IntUpdater(fieldValue reflect.Value, v reflect.Value) bool {
-	if fieldValue.Kind() == reflect.Int ||
-		fieldValue.Kind() == reflect.Int8 ||
-		fieldValue.Kind() == reflect.Int16 ||
-		fieldValue.Kind() == reflect.Int32 ||
-		fieldValue.Kind() == reflect.Int64 {
+	switch fieldValue.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 
-		if v.Kind() == reflect.Int ||
-			v.Kind() == reflect.Int8 ||
-			v.Kind() == reflect.Int16 ||
-			v.Kind() == reflect.Int32 ||
-			v.Kind() == reflect.Int64 {
+		switch v.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			if fieldValue.OverflowInt(v.Int()) {
+				return false
+			}
 			fieldValue.SetInt(v.Int())
 			return true
-		} else if v.Kind() == reflect.Float32 ||
-			v.Kind() == reflect.Float64 {
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			if fieldValue.OverflowInt(int64(v.Uint())) {
+				return false
+			}
+			fieldValue.SetInt(int64(v.Uint()))
+			return true
+		case reflect.Float32, reflect.Float64:
+			if fieldValue.OverflowInt(int64(v.Float())) {
+				return false
+			}
 			fieldValue.SetInt(int64(v.Float()))
 			return true
 		}
-	} else if fieldValue.Kind() == reflect.Ptr {
-		// only process if field is pointer to any int
-		if fieldValue.Type().String() == "*int" ||
-			fieldValue.Type().String() == "*int8" ||
-			fieldValue.Type().String() == "*int16" ||
-			fieldValue.Type().String() == "*int32" ||
-			fieldValue.Type().String() == "*int64" {
-			if !v.IsValid() {
+
+	case reflect.Ptr:
+
+		if !v.IsValid() {
+			if fieldValue.Type().String() == "*int" {
+				var newNullInt *int
+				newValue := reflect.ValueOf(newNullInt)
+				fieldValue.Set(newValue)
+				return true
+			} else if fieldValue.Type().String() == "*int8" {
+				var newNullInt8 *int8
+				newValue := reflect.ValueOf(newNullInt8)
+				fieldValue.Set(newValue)
+				return true
+			} else if fieldValue.Type().String() == "*int16" {
+				var newNullInt16 *int16
+				newValue := reflect.ValueOf(newNullInt16)
+				fieldValue.Set(newValue)
+				return true
+			} else if fieldValue.Type().String() == "*int32" {
+				var newNullInt32 *int32
+				newValue := reflect.ValueOf(newNullInt32)
+				fieldValue.Set(newValue)
+				return true
+			} else if fieldValue.Type().String() == "*int64" {
+				var newNullInt64 *int64
+				newValue := reflect.ValueOf(newNullInt64)
+				fieldValue.Set(newValue)
+				return true
+			}
+		} else {
+
+			switch v.Kind() {
+			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+				vv := v.Int()
+
 				if fieldValue.Type().String() == "*int" {
-					var newNullInt *int
-					newValue := reflect.ValueOf(newNullInt)
-					fieldValue.Set(newValue)
-					return true
-				} else if fieldValue.Type().String() == "*int8" {
-					var newNullInt8 *int8
-					newValue := reflect.ValueOf(newNullInt8)
-					fieldValue.Set(newValue)
-					return true
-				} else if fieldValue.Type().String() == "*int16" {
-					var newNullInt16 *int16
-					newValue := reflect.ValueOf(newNullInt16)
-					fieldValue.Set(newValue)
-					return true
-				} else if fieldValue.Type().String() == "*int32" {
-					var newNullInt32 *int32
-					newValue := reflect.ValueOf(newNullInt32)
-					fieldValue.Set(newValue)
-					return true
-				} else if fieldValue.Type().String() == "*int64" {
-					var newNullInt64 *int64
-					newValue := reflect.ValueOf(newNullInt64)
-					fieldValue.Set(newValue)
-					return true
-				}
-			} else if v.Kind() == reflect.Int ||
-				v.Kind() == reflect.Int8 ||
-				v.Kind() == reflect.Int16 ||
-				v.Kind() == reflect.Int32 ||
-				v.Kind() == reflect.Int64 {
-				if fieldValue.Type().String() == "*int" {
-					newIntValue := int(v.Int())
+					var newIntValue int
+					if isOverflowInt(newIntValue, vv) {
+						return false
+					}
+					newIntValue = int(vv)
 					newValue := reflect.ValueOf(&newIntValue)
 					fieldValue.Set(newValue)
 					return true
 				} else if fieldValue.Type().String() == "*int8" {
-					newInt8Value := int8(v.Int())
+					var newInt8Value int8
+					if isOverflowInt(newInt8Value, vv) {
+						return false
+					}
+					newInt8Value = int8(vv)
 					newValue := reflect.ValueOf(&newInt8Value)
 					fieldValue.Set(newValue)
 					return true
 				} else if fieldValue.Type().String() == "*int16" {
-					newInt16Value := int16(v.Int())
+					var newInt16Value int16
+					if isOverflowInt(newInt16Value, vv) {
+						return false
+					}
+					newInt16Value = int16(vv)
 					newValue := reflect.ValueOf(&newInt16Value)
 					fieldValue.Set(newValue)
 					return true
 				} else if fieldValue.Type().String() == "*int32" {
-					newInt32Value := int32(v.Int())
+					var newInt32Value int32
+					if isOverflowInt(newInt32Value, vv) {
+						return false
+					}
+					newInt32Value = int32(vv)
 					newValue := reflect.ValueOf(&newInt32Value)
 					fieldValue.Set(newValue)
 					return true
 				} else if fieldValue.Type().String() == "*int64" {
-					newInt64Value := v.Int()
+					var newInt64Value int64
+					if isOverflowInt(newInt64Value, vv) {
+						return false
+					}
+					newInt64Value = vv
 					newValue := reflect.ValueOf(&newInt64Value)
 					fieldValue.Set(newValue)
 					return true
 				}
-			} else if v.Kind() == reflect.Float32 ||
-				v.Kind() == reflect.Float64 {
+			case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+				vv := v.Uint()
+
 				if fieldValue.Type().String() == "*int" {
-					newIntValue := int(v.Float())
+					var newIntValue int
+					if isOverflowInt(newIntValue, int64(vv)) {
+						return false
+					}
+					newIntValue = int(vv)
 					newValue := reflect.ValueOf(&newIntValue)
 					fieldValue.Set(newValue)
 					return true
 				} else if fieldValue.Type().String() == "*int8" {
-					newInt8Value := int8(v.Float())
+					var newInt8Value int8
+					if isOverflowInt(newInt8Value, int64(vv)) {
+						return false
+					}
+					newInt8Value = int8(vv)
 					newValue := reflect.ValueOf(&newInt8Value)
 					fieldValue.Set(newValue)
 					return true
 				} else if fieldValue.Type().String() == "*int16" {
-					newInt16Value := int16(v.Float())
+					var newInt16Value int16
+					if isOverflowInt(newInt16Value, int64(vv)) {
+						return false
+					}
+					newInt16Value = int16(vv)
 					newValue := reflect.ValueOf(&newInt16Value)
 					fieldValue.Set(newValue)
 					return true
 				} else if fieldValue.Type().String() == "*int32" {
-					newInt32Value := int32(v.Float())
+					var newInt32Value int32
+					if isOverflowInt(newInt32Value, int64(vv)) {
+						return false
+					}
+					newInt32Value = int32(vv)
 					newValue := reflect.ValueOf(&newInt32Value)
 					fieldValue.Set(newValue)
 					return true
 				} else if fieldValue.Type().String() == "*int64" {
-					newInt64Value := int64(v.Float())
+					var newInt64Value int64
+					if isOverflowInt(newInt64Value, int64(vv)) {
+						return false
+					}
+					newInt64Value = int64(vv)
+					newValue := reflect.ValueOf(&newInt64Value)
+					fieldValue.Set(newValue)
+					return true
+				}
+			case reflect.Float32, reflect.Float64:
+				vv := v.Float()
+
+				if fieldValue.Type().String() == "*int" {
+					var newIntValue int
+					if isOverflowInt(newIntValue, int64(vv)) {
+						return false
+					}
+					newIntValue = int(vv)
+					newValue := reflect.ValueOf(&newIntValue)
+					fieldValue.Set(newValue)
+					return true
+				} else if fieldValue.Type().String() == "*int8" {
+					var newInt8Value int8
+					if isOverflowInt(newInt8Value, int64(vv)) {
+						return false
+					}
+					newInt8Value = int8(vv)
+					newValue := reflect.ValueOf(&newInt8Value)
+					fieldValue.Set(newValue)
+					return true
+				} else if fieldValue.Type().String() == "*int16" {
+					var newInt16Value int16
+					if isOverflowInt(newInt16Value, int64(vv)) {
+						return false
+					}
+					newInt16Value = int16(vv)
+					newValue := reflect.ValueOf(&newInt16Value)
+					fieldValue.Set(newValue)
+					return true
+				} else if fieldValue.Type().String() == "*int32" {
+					var newInt32Value int32
+					if isOverflowInt(newInt32Value, int64(vv)) {
+						return false
+					}
+					newInt32Value = int32(vv)
+					newValue := reflect.ValueOf(&newInt32Value)
+					fieldValue.Set(newValue)
+					return true
+				} else if fieldValue.Type().String() == "*int64" {
+					var newInt64Value int64
+					if isOverflowInt(newInt64Value, int64(vv)) {
+						return false
+					}
+					newInt64Value = int64(vv)
 					newValue := reflect.ValueOf(&newInt64Value)
 					fieldValue.Set(newValue)
 					return true
 				}
 			}
+
 		}
+
+	}
+
+	return false
+}
+
+// UintUpdater update int (any int type Uint8, Uint16, Uint32, Uint64 and whether its a pointer or a value)
+func UintUpdater(fieldValue reflect.Value, v reflect.Value) bool {
+	// check for underflow first
+	switch v.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		if v.Int() < 0 {
+			return false
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		if v.Uint() < 0 {
+			return false
+		}
+	case reflect.Float32, reflect.Float64:
+		if v.Float() < 0 {
+			return false
+		}
+	}
+
+	switch fieldValue.Kind() {
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		switch v.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			if fieldValue.OverflowUint(uint64(v.Int())) {
+				return false
+			}
+			fieldValue.SetUint(uint64(v.Int()))
+			return true
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			if fieldValue.OverflowUint(v.Uint()) {
+				return false
+			}
+			fieldValue.SetUint(v.Uint())
+			return true
+		case reflect.Float32, reflect.Float64:
+			if fieldValue.OverflowUint(uint64(v.Float())) {
+				return false
+			}
+			fieldValue.SetUint(uint64(v.Float()))
+			return true
+		}
+
+	case reflect.Ptr:
+
+		if !v.IsValid() {
+			if fieldValue.Type().String() == "*uint" {
+				var newNullUint *uint
+				newValue := reflect.ValueOf(newNullUint)
+				fieldValue.Set(newValue)
+				return true
+			} else if fieldValue.Type().String() == "*uint8" {
+				var newNullUint8 *uint8
+				newValue := reflect.ValueOf(newNullUint8)
+				fieldValue.Set(newValue)
+				return true
+			} else if fieldValue.Type().String() == "*uint16" {
+				var newNullUint16 *uint16
+				newValue := reflect.ValueOf(newNullUint16)
+				fieldValue.Set(newValue)
+				return true
+			} else if fieldValue.Type().String() == "*uint32" {
+				var newNullUint32 *uint32
+				newValue := reflect.ValueOf(newNullUint32)
+				fieldValue.Set(newValue)
+				return true
+			} else if fieldValue.Type().String() == "*uint64" {
+				var newNullUint64 *uint64
+				newValue := reflect.ValueOf(newNullUint64)
+				fieldValue.Set(newValue)
+				return true
+			}
+		} else {
+
+			switch v.Kind() {
+			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+				vv := v.Int()
+
+				if fieldValue.Type().String() == "*uint" {
+					var newUintValue uint
+					if isOverflowUint(newUintValue, uint64(vv)) {
+						return false
+					}
+					newUintValue = uint(vv)
+					newValue := reflect.ValueOf(&newUintValue)
+					fieldValue.Set(newValue)
+					return true
+				} else if fieldValue.Type().String() == "*uint8" {
+					var newUint8Value uint8
+					if isOverflowUint(newUint8Value, uint64(vv)) {
+						return false
+					}
+					newUint8Value = uint8(vv)
+					newValue := reflect.ValueOf(&newUint8Value)
+					fieldValue.Set(newValue)
+					return true
+				} else if fieldValue.Type().String() == "*uint16" {
+					var newUint16Value uint16
+					if isOverflowUint(newUint16Value, uint64(vv)) {
+						return false
+					}
+					newUint16Value = uint16(vv)
+					newValue := reflect.ValueOf(&newUint16Value)
+					fieldValue.Set(newValue)
+					return true
+				} else if fieldValue.Type().String() == "*uint32" {
+					var newUint32Value uint32
+					if isOverflowUint(newUint32Value, uint64(vv)) {
+						return false
+					}
+					newUint32Value = uint32(vv)
+					newValue := reflect.ValueOf(&newUint32Value)
+					fieldValue.Set(newValue)
+					return true
+				} else if fieldValue.Type().String() == "*uint64" {
+					var newUint64Value uint64
+					if isOverflowUint(newUint64Value, uint64(vv)) {
+						return false
+					}
+					newUint64Value = uint64(vv)
+					newValue := reflect.ValueOf(&newUint64Value)
+					fieldValue.Set(newValue)
+					return true
+				}
+			case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+				vv := v.Uint()
+
+				if fieldValue.Type().String() == "*uint" {
+					var newUintValue uint
+					if isOverflowUint(newUintValue, vv) {
+						return false
+					}
+					newUintValue = uint(vv)
+					newValue := reflect.ValueOf(&newUintValue)
+					fieldValue.Set(newValue)
+					return true
+				} else if fieldValue.Type().String() == "*uint8" {
+					var newUint8Value uint8
+					if isOverflowUint(newUint8Value, vv) {
+						return false
+					}
+					newUint8Value = uint8(vv)
+					newValue := reflect.ValueOf(&newUint8Value)
+					fieldValue.Set(newValue)
+					return true
+				} else if fieldValue.Type().String() == "*uint16" {
+					var newUint16Value uint16
+					if isOverflowUint(newUint16Value, vv) {
+						return false
+					}
+					newUint16Value = uint16(vv)
+					newValue := reflect.ValueOf(&newUint16Value)
+					fieldValue.Set(newValue)
+					return true
+				} else if fieldValue.Type().String() == "*uint32" {
+					var newUint32Value uint32
+					if isOverflowUint(newUint32Value, vv) {
+						return false
+					}
+					newUint32Value = uint32(vv)
+					newValue := reflect.ValueOf(&newUint32Value)
+					fieldValue.Set(newValue)
+					return true
+				} else if fieldValue.Type().String() == "*uint64" {
+					var newUint64Value uint64
+					if isOverflowUint(newUint64Value, vv) {
+						return false
+					}
+					newUint64Value = vv
+					newValue := reflect.ValueOf(&newUint64Value)
+					fieldValue.Set(newValue)
+					return true
+				}
+			case reflect.Float32, reflect.Float64:
+				vv := v.Float()
+
+				if fieldValue.Type().String() == "*uint" {
+					var newUintValue uint
+					if isOverflowUint(newUintValue, uint64(vv)) {
+						return false
+					}
+					newUintValue = uint(vv)
+					newValue := reflect.ValueOf(&newUintValue)
+					fieldValue.Set(newValue)
+					return true
+				} else if fieldValue.Type().String() == "*uint8" {
+					var newUint8Value uint8
+					if isOverflowUint(newUint8Value, uint64(vv)) {
+						return false
+					}
+					newUint8Value = uint8(vv)
+					newValue := reflect.ValueOf(&newUint8Value)
+					fieldValue.Set(newValue)
+					return true
+				} else if fieldValue.Type().String() == "*uint16" {
+					var newUint16Value uint16
+					if isOverflowUint(newUint16Value, uint64(vv)) {
+						return false
+					}
+					newUint16Value = uint16(vv)
+					newValue := reflect.ValueOf(&newUint16Value)
+					fieldValue.Set(newValue)
+					return true
+				} else if fieldValue.Type().String() == "*uint32" {
+					var newUint32Value uint32
+					if isOverflowUint(newUint32Value, uint64(vv)) {
+						return false
+					}
+					newUint32Value = uint32(vv)
+					newValue := reflect.ValueOf(&newUint32Value)
+					fieldValue.Set(newValue)
+					return true
+				} else if fieldValue.Type().String() == "*uint64" {
+					var newUint64Value uint64
+					if isOverflowUint(newUint64Value, uint64(vv)) {
+						return false
+					}
+					newUint64Value = uint64(vv)
+					newValue := reflect.ValueOf(&newUint64Value)
+					fieldValue.Set(newValue)
+					return true
+				}
+			}
+
+		}
+
 	}
 
 	return false
@@ -292,68 +615,122 @@ func IntUpdater(fieldValue reflect.Value, v reflect.Value) bool {
 
 // FloatUpdater update int (any float type Float8, Float16, Float32, Float64 and whether its a pointer or a value)
 func FloatUpdater(fieldValue reflect.Value, v reflect.Value) bool {
-	if fieldValue.Kind() == reflect.Float32 ||
-		fieldValue.Kind() == reflect.Float64 {
+	switch fieldValue.Kind() {
+	case reflect.Float32, reflect.Float64:
 
-		if v.Kind() == reflect.Int ||
-			v.Kind() == reflect.Int8 ||
-			v.Kind() == reflect.Int16 ||
-			v.Kind() == reflect.Int32 ||
-			v.Kind() == reflect.Int64 {
+		switch v.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			if fieldValue.OverflowFloat(float64(v.Int())) {
+				return false
+			}
 			fieldValue.SetFloat(float64(v.Int()))
 			return true
-		} else if v.Kind() == reflect.Float32 ||
-			v.Kind() == reflect.Float64 {
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			if fieldValue.OverflowFloat(float64(v.Uint())) {
+				return false
+			}
+			fieldValue.SetFloat(float64(v.Uint()))
+			return true
+		case reflect.Float32, reflect.Float64:
+			if fieldValue.OverflowFloat(v.Float()) {
+				return false
+			}
 			fieldValue.SetFloat(v.Float())
 			return true
 		}
-	} else if fieldValue.Kind() == reflect.Ptr {
+
+	case reflect.Ptr:
+
 		// only process if field is pointer to any float
-		if fieldValue.Type().String() == "*float32" ||
-			fieldValue.Type().String() == "*float64" {
-			if !v.IsValid() {
+		if fieldValue.Type().String() != "*float32" && fieldValue.Type().String() != "*float64" {
+			return false
+		}
+
+		if !v.IsValid() {
+			if fieldValue.Type().String() == "*float32" {
+				var newFloat32Value *float32
+				newValue := reflect.ValueOf(newFloat32Value)
+				fieldValue.Set(newValue)
+				return true
+			} else if fieldValue.Type().String() == "*float64" {
+				var newFloat64Value *float64
+				newValue := reflect.ValueOf(newFloat64Value)
+				fieldValue.Set(newValue)
+				return true
+			}
+		} else {
+
+			switch v.Kind() {
+			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+				vv := v.Int()
+
 				if fieldValue.Type().String() == "*float32" {
-					var newFloat32Value *float32
-					newValue := reflect.ValueOf(newFloat32Value)
-					fieldValue.Set(newValue)
-					return true
-				} else if fieldValue.Type().String() == "*float64" {
-					var newFloat64Value *float64
-					newValue := reflect.ValueOf(newFloat64Value)
-					fieldValue.Set(newValue)
-					return true
-				}
-			} else if v.Kind() == reflect.Int ||
-				v.Kind() == reflect.Int8 ||
-				v.Kind() == reflect.Int16 ||
-				v.Kind() == reflect.Int32 ||
-				v.Kind() == reflect.Int64 {
-				if fieldValue.Type().String() == "*float32" {
-					newFloat32Value := float32(v.Int())
+					var newFloat32Value float32
+					if isOverflowFloat(newFloat32Value, float64(vv)) {
+						return false
+					}
+					newFloat32Value = float32(vv)
 					newValue := reflect.ValueOf(&newFloat32Value)
 					fieldValue.Set(newValue)
 					return true
 				} else if fieldValue.Type().String() == "*float64" {
-					newFloat64Value := float64(v.Int())
+					var newFloat64Value float64
+					if isOverflowFloat(newFloat64Value, float64(vv)) {
+						return false
+					}
+					newFloat64Value = float64(vv)
 					newValue := reflect.ValueOf(&newFloat64Value)
 					fieldValue.Set(newValue)
 					return true
 				}
-			} else if v.Kind() == reflect.Float32 ||
-				v.Kind() == reflect.Float64 {
+			case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+				vv := v.Uint()
+
 				if fieldValue.Type().String() == "*float32" {
-					newFloat32Value := float32(v.Float())
+					var newFloat32Value float32
+					if isOverflowFloat(newFloat32Value, float64(vv)) {
+						return false
+					}
+					newFloat32Value = float32(vv)
 					newValue := reflect.ValueOf(&newFloat32Value)
 					fieldValue.Set(newValue)
 					return true
 				} else if fieldValue.Type().String() == "*float64" {
-					newFloat64Value := v.Float()
+					var newFloat64Value float64
+					if isOverflowFloat(newFloat64Value, float64(vv)) {
+						return false
+					}
+					newFloat64Value = float64(vv)
+					newValue := reflect.ValueOf(&newFloat64Value)
+					fieldValue.Set(newValue)
+					return true
+				}
+			case reflect.Float32, reflect.Float64:
+				vv := v.Float()
+
+				if fieldValue.Type().String() == "*float32" {
+					var newFloat32Value float32
+					if isOverflowFloat(newFloat32Value, vv) {
+						return false
+					}
+					newFloat32Value = float32(vv)
+					newValue := reflect.ValueOf(&newFloat32Value)
+					fieldValue.Set(newValue)
+					return true
+				} else if fieldValue.Type().String() == "*float64" {
+					var newFloat64Value float64
+					if isOverflowFloat(newFloat64Value, vv) {
+						return false
+					}
+					newFloat64Value = vv
 					newValue := reflect.ValueOf(&newFloat64Value)
 					fieldValue.Set(newValue)
 					return true
 				}
 			}
+
 		}
+
 	}
 
 	return false
@@ -366,8 +743,17 @@ func TimeUpdater(fieldValue reflect.Value, v reflect.Value) bool {
 		if !v.IsValid() {
 			return false
 		}
-		// only set if underlying type is string
-		if v.Kind() == reflect.String {
+
+		switch v.Kind() {
+		case reflect.Int64:
+			t := time.Unix(v.Int(), 0)
+			fieldValue.Set(reflect.ValueOf(t))
+			return true
+		case reflect.Float64:
+			t := time.Unix(int64(v.Float()), 0)
+			fieldValue.Set(reflect.ValueOf(t))
+			return true
+		case reflect.String:
 			t := time.Now()
 			// make sure date format is correct
 			if err := t.UnmarshalJSON([]byte(`"` + v.String() + `"`)); err == nil {
@@ -383,8 +769,17 @@ func TimeUpdater(fieldValue reflect.Value, v reflect.Value) bool {
 			fieldValue.Set(newValue)
 			return true
 		}
-		// only set if underlying type is string
-		if v.Kind() == reflect.String {
+
+		switch v.Kind() {
+		case reflect.Int64:
+			t := time.Unix(v.Int(), 0)
+			fieldValue.Set(reflect.ValueOf(&t))
+			return true
+		case reflect.Float64:
+			t := time.Unix(int64(v.Float()), 0)
+			fieldValue.Set(reflect.ValueOf(&t))
+			return true
+		case reflect.String:
 			t := time.Now()
 			// make sure date format is correct
 			if err := t.UnmarshalJSON([]byte(`"` + v.String() + `"`)); err == nil {
@@ -398,15 +793,22 @@ func TimeUpdater(fieldValue reflect.Value, v reflect.Value) bool {
 	return false
 }
 
+func isOverflowUint(field interface{}, value uint64) bool {
+	return reflect.ValueOf(field).OverflowUint(value)
+}
+
+func isOverflowInt(field interface{}, value int64) bool {
+	return reflect.ValueOf(field).OverflowInt(value)
+}
+
+func isOverflowFloat(field interface{}, value float64) bool {
+	return reflect.ValueOf(field).OverflowFloat(value)
+}
+
 // Updaters collection of all type updaters
 var Updaters = []func(reflect.Value, reflect.Value) bool{
-	NullStringUpdater,
-	NullFloatUpdater,
-	NullIntUpdater,
-	NullBoolUpdater,
-	NullTimeUpdater,
-	MapStringInterfaceUpdater,
 	IntUpdater,
+	UintUpdater,
 	FloatUpdater,
 	TimeUpdater,
 	BoolUpdater,


### PR DESCRIPTION
- Add support for uint data type
- Add support to assign time.Time and *time.Time from int64 (unix time) and float64 (if you use protobuf wkt struct as message type)
- Add underflow check for uint and overflow check for int, uint, and float (overflow check for int64, uint64, float64 are not working fine at the moment, still need improvement)